### PR TITLE
Add CI/CD workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,13 +1,12 @@
-#  === To test locally ===
-#  ```
-#  act --env AWS_ACCESS_KEY_ID=<foo> --env AWS_SECRET_ACCESS_KEY=<bar>
-#  ```
-
 name: CI/CD pipeline
 
 on:
   push:
     branches: main
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
 
 jobs:
   pre-commit:
@@ -22,6 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: pre-commit
     steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::691456347435:role/github-workflow-runner
+          role-session-name: deploy
+          # us-east-1 required since we're managing CloudFront resources
+          aws-region: us-east-1
       - name: Derive stack name
         env:
           DEFAULT_BRANCH: github.event.repository.default_branch

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2,7 +2,6 @@ name: CI/CD pipeline
 
 on:
   push:
-#    branches: main
   schedule:
     - cron: '0 0 * * 6'  # Run every Saturday at 9 AM JST
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,6 +3,8 @@ name: CI/CD pipeline
 on:
   push:
 #    branches: main
+  schedule:
+    - cron: '0 0 * * 6'  # Run every Saturday at 9 AM JST
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -22,7 +24,7 @@ jobs:
     needs: pre-commit
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::691456347435:role/github-workflow-runner
           role-session-name: deploy

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,39 @@
+#  === To test locally ===
+#  ```
+#  act --env AWS_ACCESS_KEY_ID=<foo> --env AWS_SECRET_ACCESS_KEY=<bar>
+#  ```
+
+name: CI/CD pipeline
+
+on:
+  push:
+    branches: main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - run: pre-commit run --all-files
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    steps:
+      - name: Derive stack name
+        env:
+          DEFAULT_BRANCH: github.event.repository.default_branch
+        run: |
+          STACK_NAME=beta
+          if [ "${{ github.ref_name }}" == "$DEFAULT_BRANCH" ]; then
+            STACK_NAME=prod
+          fi
+          echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+      - name: Install CDK
+        run: npm install -g aws-cdk
+      - run: cdk deploy "${STACK_NAME}"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2,7 +2,7 @@ name: CI/CD pipeline
 
 on:
   push:
-    branches: main
+#    branches: main
 
 permissions:
   id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
Previously the deployment was manual. Now we have a workflow that runs both the deployment to prod and the pre-commit periodically. The periodic check allows us to catch dependencies that broke beneath our feet.

__Out of scope__

Testing in main that actually deploys to prod. By default the workflow deploys to beta.

__Testing done__

https://github.com/boonjiashen/boonjiashen-dot-com-infra/actions/runs/10259041558
Succeeds in beta