### PR TITLE
Fix deployment on default branch

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -31,7 +31,7 @@ jobs:
           aws-region: us-east-1
       - name: Derive stack name
         env:
-          DEFAULT_BRANCH: github.event.repository.default_branch
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           echo "${DEFAULT_BRANCH}"
           STACK_NAME=beta

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -33,10 +33,8 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          echo "${DEFAULT_BRANCH}"
           STACK_NAME=beta
-          #          if [ "${{ github.ref_name }}" == $DEFAULT_BRANCH ]; then
-          if [ "main" == $DEFAULT_BRANCH ]; then
+          if [ "${{ github.ref_name }}" == $DEFAULT_BRANCH ]; then
             STACK_NAME=prod
           fi
           echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -33,8 +33,9 @@ jobs:
         env:
           DEFAULT_BRANCH: github.event.repository.default_branch
         run: |
+          echo "${DEFAULT_BRANCH}"
           STACK_NAME=beta
-          if [ "${{ github.ref_name }}" == "$DEFAULT_BRANCH" ]; then
+          if [ "${{ github.ref_name }}" == $DEFAULT_BRANCH ]; then
             STACK_NAME=prod
           fi
           echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -35,7 +35,8 @@ jobs:
         run: |
           echo "${DEFAULT_BRANCH}"
           STACK_NAME=beta
-          if [ "${{ github.ref_name }}" == $DEFAULT_BRANCH ]; then
+          #          if [ "${{ github.ref_name }}" == $DEFAULT_BRANCH ]; then
+          if [ "main" == $DEFAULT_BRANCH ]; then
             STACK_NAME=prod
           fi
           echo "STACK_NAME=$STACK_NAME" >> $GITHUB_ENV


### PR DESCRIPTION
Previously the envvar didn't have the `${{ }}` and ref was taken as a literal rather than evaluated.

__Testing done__

https://github.com/boonjiashen/boonjiashen-dot-com-infra/actions/runs/10259233275/job/28383365439

Deploys to prod if I change the left-hand operator of `if curr-branch == $DEFAULT_BRANCH` to be a literal `main`