### PR TITLE
chore: Upgrade NodeJs18 to 20

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -4,7 +4,7 @@ on:
   push:
   schedule:
     - cron: '0 0 * * 6'  # Run every Saturday at 9 AM JST
-
+  workflow_dispatch:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout


### PR DESCRIPTION
Because the former is getting deprecated. These are upgraded by upgrading aws-cdk-lib, whose custom Lambda functions use NodeJS.

## Testing done

```console
$ cdk deploy beta

✨  Synthesis time: 2.89s

beta (betaDomainInfraStack): deploying... [1/1]
betaDomainInfraStack: creating CloudFormation changeset...

 ✅  beta (betaDomainInfraStack)

✨  Deployment time: 124.57s

Outputs:
beta.blogGithubManagementPage = https://github.com/boonjiashen2/boonjiashen2.github.io/settings/pages
beta.blogSubdomain = blog.dev.boonjiashen.com
beta.hostzoneAttr = {"hostedZoneId":"Z063915120I77LJYUUWXL","zoneName":"dev.boonjiashen.com"}
beta.nameServers = ns-227.awsdns-28.com,ns-1245.awsdns-27.org,ns-843.awsdns-41.net,ns-1760.awsdns-28.co.uk
Stack ARN:
arn:aws:cloudformation:us-east-1:691456347435:stack/betaDomainInfraStack/fee48690-1e71-11ec-8a5d-0a6e3cc243cd

✨  Total time: 127.46s
```
