### PR TITLE
feat: add workflow-dispatch to cicd

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -4,7 +4,7 @@ on:
   push:
   schedule:
     - cron: '0 0 * * 6'  # Run every Saturday at 9 AM JST
-
+  workflow_dispatch:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * 6'  # Run every Saturday at 9 AM JST
   workflow_dispatch:
+
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout


### PR DESCRIPTION
So that we have more flexibility in testing the pipeline. Previously we depended on time (with schedule) and code changes (on.push)

## Testing done

None, since workflow_dispatch only appears after merging to main